### PR TITLE
Handle escape in webshell

### DIFF
--- a/webshell/src/lib.rs
+++ b/webshell/src/lib.rs
@@ -1,17 +1,15 @@
-// ZQM:
-extern crate zqm_engine;
-use zqm_engine::{eval, types::{render, event::{Event, KeyEventInfo}}};
-
 use wasm_bindgen::prelude::*;
 
 use std::f64;
 
 use web_sys::{self, console};
-//use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 use std::rc::Rc;
 use std::cell::Cell;
+
+extern crate zqm_engine;
+use zqm_engine::{eval, types::{render, event::{Event, KeyEventInfo}}};
 
 pub fn draw_elms(
     elms: &render::Elms,
@@ -28,10 +26,6 @@ pub fn draw_elms(
         .unwrap()
         .dyn_into::<web_sys::CanvasRenderingContext2d>()
         .unwrap();
-
-    // draw background; test canvas
-    //context.set_fill_style(&"rgb(250,250,240)".into());
-    //context.fill_rect(0.0, 0.0, 666.0, 666.0);
 
     fn translate_color(c:&render::Color) -> JsValue {
         match c {
@@ -86,29 +80,13 @@ pub fn console_log(m:String) {
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]
 pub fn main() -> Result<(), JsValue> {
-    let state_cell = Rc::new(Cell::new(eval::init_state()));
-    let window = web_sys::window().expect("no global `window` exists");
-    let document = window.document().expect("should have a document on window");
-
+    let mut state = eval::init_state();
+    draw_elms(&eval::render_elms(&mut state).unwrap());
+    let state_cell = Rc::new(Cell::new(state));
     let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
         let mut state : eval::State = state_cell.replace(eval::init_state());
-
-        if false {
-            let msg : JsValue = format!(
-                "{} {} {} {} {} {}",
-                event.key(),
-                event.code(),
-                event.shift_key(),
-                event.ctrl_key(),
-                event.alt_key(),
-                event.meta_key()
-            ).into();
-            console::log_1(&msg);
-        }
-
-        // translate each system event into zero, one or more in the engine's format.
-        // get commands from the engine, and run the commands for each event in the engine.
         let render_elms = {
+            // translate each system event into zero, one or more in the engine's format.
             let events =
                 match format!("{}", event.key()).as_str() {
                     "Escape" |
@@ -118,7 +96,6 @@ pub fn main() -> Result<(), JsValue> {
                     "ArrowRight" |
                     " " =>
                     {
-                        console_log(format!("recognized key: {}", event.key()));
                         vec![
                             Event::KeyDown(KeyEventInfo{
                                 key: event.key(),
@@ -135,25 +112,43 @@ pub fn main() -> Result<(), JsValue> {
                     }
                 };
 
-            // for each event, get commands; for each command; eval it.
-            console_log(format!("events: {:?}", events));
+            if false {
+                console_log(format!("event key {} ==> events {:?}", event.key(), events));
+            };
+            // for each engine event, get commands from the engine,
+            //   and run the commands in the engine, updating the state.
             for event in events.iter() {
-                let commands = eval::commands_of_event(&mut state, event).unwrap();
-                for command in commands.iter() {
-                    eval::command_eval(&mut state, command).unwrap();
+                let commands = eval::commands_of_event(&mut state, event);
+                match commands {
+                    Ok(commands) => {
+                        for command in commands.iter() {
+                            let res = eval::command_eval(&mut state, command);
+                            console_log(format!("eval({:?}) ==> {:?}", command, res))
+                        }
+                    },
+                    Err(_) => {
+                        // User is asking to escape; reset the state
+                        state = eval::init_state();
+                    }
                 }
-            }
+            };
+
+            // get engine's render elements from updated state
             eval::render_elms(&mut state).unwrap()
         };
-        // save the new state, and draaw it.
+        // save updated state
         state_cell.set(state);
+        // draw the engine elements onto the document's canvas element
         draw_elms(&render_elms);
 
     }) as Box<dyn FnMut(_)>);
-    //document.set_onkeypress(Some(closure.as_ref().unchecked_ref()));
+
+    let document = web_sys::window().unwrap().document().unwrap();
     document.set_onkeydown(Some(closure.as_ref().unchecked_ref()));
+    //document.set_onkeypress(Some(closure.as_ref().unchecked_ref()));
     //document.set_onkeyup(Some(closure.as_ref().unchecked_ref()));
     //document.set_oninput(Some(closure.as_ref().unchecked_ref()));
     closure.forget();
+
     Ok(())
 }


### PR DESCRIPTION
- Before, the escape key was ignored.  Now, we handle it by resetting the bitmap.
- Other misc cleanup and simplification to the `webshell` code